### PR TITLE
Update Splunk starting arguments

### DIFF
--- a/chapter3/docker-compose.yml_network
+++ b/chapter3/docker-compose.yml_network
@@ -5,7 +5,7 @@ services:
     image: splunk/splunk
     hostname: splunkserver
     environment:
-      SPLUNK_START_ARGS: --accept-license --answer-yes
+      SPLUNK_START_ARGS: --accept-license --answer-yes --seed-passwd changeme
       SPLUNK_ENABLE_LISTEN: 9997
       SPLUNK_USER: root
     ports:


### PR DESCRIPTION
Without a password, Splunk will never startup in the latest version, so it's better to have backward-compatibility as well as future-proofing.