### PR TITLE
Update Splunk starting arguments

### DIFF
--- a/chapter3/docker-compose.yml_volumes
+++ b/chapter3/docker-compose.yml_volumes
@@ -5,7 +5,7 @@ services:
     image: splunk/splunk
     hostname: splunkserver
     environment:
-      SPLUNK_START_ARGS: --accept-license --answer-yes
+      SPLUNK_START_ARGS: --accept-license --answer-yes --seed-passwd changeme
       SPLUNK_ENABLE_LISTEN: 9997
       SPLUNK_USER: root
     ports:
@@ -23,7 +23,7 @@ services:
     image: splunk/universalforwarder
     hostname: splunkforwarder
     environment:
-      SPLUNK_START_ARGS: --accept-license --answer-yes
+      SPLUNK_START_ARGS: --accept-license --answer-yes --seed-passwd changeme
       SPLUNK_FORWARD_SERVER: splunkserver:9997
       SPLUNK_USER: root
     labels:


### PR DESCRIPTION
Without a password, Splunk will never startup in the latest version, so it's better to have backward-compatibility as well as future-proofing.